### PR TITLE
Use flags for tournament parameters

### DIFF
--- a/cmd/prisoner/main.go
+++ b/cmd/prisoner/main.go
@@ -18,7 +18,7 @@ func main() {
 	flag.Parse()
 
 	prisoner := pkg.New()
-	players := prisoner.GetPersonalities(10)
-	prisoner.PlayTournament(players, 5)
+	players := prisoner.GetPersonalities(numOfEnts)
+	prisoner.PlayTournament(players, numOfRounds)
 	prisoner.PrintResults(players)
 }


### PR DESCRIPTION
## Summary
- use command line flags to determine the number of players and rounds

## Testing
- `go vet ./...` *(fails: Forbidden)*
- `go test ./...` *(fails: Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_6859dfd3ab748331b647d530d51c0b91