### PR TITLE
Implement comprehensive logging across all components

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 bin
-# prisonerdb
+prisonerdb
+*.db.json

--- a/api/server_test.go
+++ b/api/server_test.go
@@ -4,16 +4,19 @@ import (
 	"bytes"
 	"fmt"
 	"io"
+	"log/slog"
 	"net/http"
 	"net/http/httptest"
 	"reflect"
 	"testing"
 
 	"github.com/google/uuid"
-	"github.com/iancullinane/prisoner/internal/logging"
 	"github.com/iancullinane/prisoner/internal/types"
 	"github.com/iancullinane/prisoner/pkg/prisoner"
 )
+
+// testLogger discards output; these tests assert on HTTP behaviour, not logs.
+func testLogger() *slog.Logger { return slog.New(slog.DiscardHandler) }
 
 var (
 	// luigi        = types.Player{Name: "Luigi", ID: luigiID}
@@ -37,7 +40,7 @@ func TestPlayers_Get(t *testing.T) {
 		},
 	}
 
-	server := NewPlayerServer(logging.NewLogger(), &playerStore, nil)
+	server := NewPlayerServer(testLogger(), &playerStore, nil)
 
 	tests := []struct {
 		name string
@@ -87,7 +90,7 @@ func TestCreatePlayers(t *testing.T) {
 			{ID: playerID2, Name: "Luigi"},
 		},
 	}
-	server := NewPlayerServer(logging.NewLogger(), &playerStore, nil)
+	server := NewPlayerServer(testLogger(), &playerStore, nil)
 
 	tests := []struct {
 		name     string
@@ -135,7 +138,7 @@ func TestPlay(t *testing.T) {
 		},
 	}
 	historyStore := StubHistoryStore{}
-	server := NewPlayerServer(logging.NewLogger(), &playerStore, &historyStore)
+	server := NewPlayerServer(testLogger(), &playerStore, &historyStore)
 
 	tests := []struct {
 		name string
@@ -197,7 +200,7 @@ func TestHistory_Get(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 
 			historyStore := StubHistoryStore{history: tc.history}
-			server := NewPlayerServer(logging.NewLogger(), &StubPlayerStore{}, &historyStore)
+			server := NewPlayerServer(testLogger(), &StubPlayerStore{}, &historyStore)
 
 			request := newHistoryRequest(tc.pID)
 			response := httptest.NewRecorder()

--- a/cmd/player.go
+++ b/cmd/player.go
@@ -1,0 +1,64 @@
+/*
+Copyright © 2026 NAME HERE <EMAIL ADDRESS>
+*/
+package cmd
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/spf13/cobra"
+	"github.com/spf13/viper"
+)
+
+// var (
+// 	player1, _ = uuid.FromBytes([]byte("player1"))
+// 	player2, _ = uuid.FromBytes([]byte("player2"))
+// )
+
+// playerCmd represents the play command
+var playerCmd = &cobra.Command{
+	Use:   "player",
+	Short: "Commands related to players",
+	Args:  cobra.ExactArgs(1),
+	RunE: func(cmd *cobra.Command, args []string) error {
+		storeKind := viper.GetString("store")
+
+		// set stores, one for players and one for history
+		st, cleanup, err := openStores(context.Background(), storeKind, logger)
+		if err != nil {
+			return err
+		}
+		defer cleanup()
+
+		playerStore := st.players
+
+		playerName := args[0]
+		fmt.Printf("Using %s store for player %q\n", storeKind, playerName)
+
+		player, err := playerStore.GetPlayerByName(playerName)
+		if err != nil {
+			return fmt.Errorf("getting player from %s store: %w", storeKind, err)
+		}
+		fmt.Printf("Player: %+v\n", player)
+
+		return nil
+	},
+}
+
+func init() {
+	rootCmd.AddCommand(playerCmd)
+
+	// playerCmd.Flags().String("scoring", "positive", "scoring system to use, accepts, classic or positive")
+	// _ = viper.BindPFlag("scoring", playerCmd.Flags().Lookup("scoring"))
+
+	// Here you will define your flags and configuration settings.
+
+	// Cobra supports Persistent Flags which will work for this command
+	// and all subcommands, e.g.:
+	// playCmd.PersistentFlags().String("foo", "", "A help for foo")
+
+	// Cobra supports local flags which will only run when this command
+	// is called directly, e.g.:
+	// playCmd.Flags().BoolP("toggle", "t", false, "Help message for toggle")
+}

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -5,13 +5,20 @@ package cmd
 
 import (
 	"fmt"
+	"log/slog"
 	"os"
 
+	"github.com/iancullinane/prisoner/internal/logging"
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
 )
 
 var cfgFile string
+
+// logger is the process-wide root logger, built from the resolved config in
+// PersistentPreRunE before any subcommand runs. Commands derive component
+// loggers from it when constructing stores and servers.
+var logger *slog.Logger
 
 // rootCmd represents the base command when called without any subcommands
 var rootCmd = &cobra.Command{
@@ -33,6 +40,18 @@ Scoring mechanisms convert these symbols based on the payoff matrix used.
 
 Use this CLI to play rounds from the terminal and to experiment with
 strategies and simulations as the tool grows.`,
+	// PersistentPreRunE runs for every subcommand after config is loaded, so the
+	// logger reflects the resolved --log-level / --log-format (flag, env, config,
+	// then default). Subcommands read the package-level logger var.
+	PersistentPreRunE: func(cmd *cobra.Command, args []string) error {
+		level := logging.ParseLevel(viper.GetString("log-level"))
+		logger = logging.New(os.Stdout, level, viper.GetString("log-format"))
+		logger.Debug("logger initialised",
+			slog.String("log_level", level.String()),
+			slog.String("log_format", viper.GetString("log-format")),
+		)
+		return nil
+	},
 }
 
 // Execute adds all child commands to the root command and sets flags appropriately.
@@ -50,6 +69,11 @@ func init() {
 	rootCmd.PersistentFlags().StringVar(&cfgFile, "config", "", "config file (default is $HOME/.prisoner)")
 	rootCmd.PersistentFlags().String("store", StoreMemory, "player store backend: memory, file, or postgres")
 	_ = viper.BindPFlag("store", rootCmd.PersistentFlags().Lookup("store"))
+
+	rootCmd.PersistentFlags().String("log-level", "debug", "log level: debug, info, warn, or error")
+	rootCmd.PersistentFlags().String("log-format", "text", "log output format: text or json")
+	_ = viper.BindPFlag("log-level", rootCmd.PersistentFlags().Lookup("log-level"))
+	_ = viper.BindPFlag("log-format", rootCmd.PersistentFlags().Lookup("log-format"))
 }
 
 // initConfig reads in config file and ENV variables if set.
@@ -75,6 +99,8 @@ func initConfig() {
 	viper.SetEnvPrefix("prisoner")
 	viper.SetDefault("store", StoreMemory)
 	viper.SetDefault("scoring", "classic")
+	viper.SetDefault("log-level", "debug")
+	viper.SetDefault("log-format", "text")
 
 	viper.AutomaticEnv()
 

--- a/cmd/server.go
+++ b/cmd/server.go
@@ -5,12 +5,10 @@ package cmd
 
 import (
 	"context"
-	"fmt"
 	"log/slog"
 	"net/http"
 
 	"github.com/iancullinane/prisoner/api"
-	"github.com/iancullinane/prisoner/internal/logging"
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
 )
@@ -22,21 +20,19 @@ var serverCmd = &cobra.Command{
 	Long:  `Server will start a long running process serving HTTP requests. Takes the same store flags as using the CLI app. Supports memory, file, and postgres stores.`,
 	RunE: func(cmd *cobra.Command, args []string) error {
 		storeKind := viper.GetString("store")
-		st, cleanup, err := openStores(context.Background(), storeKind)
+
+		log := logger.With(slog.String("service", "prisoner"))
+
+		st, cleanup, err := openStores(context.Background(), storeKind, log)
 		if err != nil {
 			return err
 		}
 		defer cleanup()
 
-		fmt.Printf("starting server (%s store)...\n", storeKind)
-		logger := logging.NewLogger()
-		logger.With(
-			slog.String("service", "prisoner"),
-		)
-		logger.Info("starting server")
+		log.Info("starting server", slog.String("store", storeKind))
 
-		server := api.NewPlayerServer(logger, st.players, st.history)
-		logger.Info("listening on :5001")
+		server := api.NewPlayerServer(log, st.players, st.history)
+		log.Info("listening on :5001")
 		return http.ListenAndServe(":5001", server)
 	},
 }

--- a/cmd/simulate.go
+++ b/cmd/simulate.go
@@ -40,7 +40,7 @@ var simulateCmd = &cobra.Command{
 		}
 
 		// set stores, one for players and one for history
-		st, cleanup, err := openStores(context.Background(), storeKind)
+		st, cleanup, err := openStores(context.Background(), storeKind, logger)
 		if err != nil {
 			return err
 		}
@@ -54,7 +54,6 @@ var simulateCmd = &cobra.Command{
 		}
 		fmt.Printf("Using %s store (%d interactions in history)\n", storeKind, len(history))
 
-		//------------------------/------------------------/------------------------
 		roundCount, err := strconv.Atoi(args[0])
 		if err != nil {
 			return err

--- a/cmd/store-opener.go
+++ b/cmd/store-opener.go
@@ -3,6 +3,7 @@ package cmd
 import (
 	"context"
 	"fmt"
+	"log/slog"
 	"os"
 
 	"github.com/iancullinane/prisoner/db"
@@ -33,20 +34,20 @@ type stores struct {
 // openStores selects an in-memory, file-based, or database backed storage
 // system and constructs both the player and history stores from a single
 // connection. The returned cleanup is always safe to call.
-func openStores(ctx context.Context, kind string) (stores, func(), error) {
+func openStores(ctx context.Context, kind string, logger *slog.Logger) (stores, func(), error) {
 	switch kind {
 	case StoreMemory, "":
 		return stores{
-			players: memory.NewInMemoryPlayerStore(),
-			history: memory.NewInMemoryHistoryStore(),
+			players: memory.NewInMemoryPlayerStore(logger),
+			history: memory.NewInMemoryHistoryStore(logger),
 		}, func() {}, nil
 
 	case StoreFile:
-		players, closePlayers, err := openPlayerFileStore()
+		players, closePlayers, err := openPlayerFileStore(logger)
 		if err != nil {
 			return stores{}, nil, err
 		}
-		history, closeHistory, err := openHistoryFileStore()
+		history, closeHistory, err := openHistoryFileStore(logger)
 		if err != nil {
 			closePlayers()
 			return stores{}, nil, err
@@ -55,13 +56,13 @@ func openStores(ctx context.Context, kind string) (stores, func(), error) {
 			func() { closeHistory(); closePlayers() }, nil
 
 	case StorePostgres:
-		pool, err := openPostgresPool(ctx)
+		pool, err := openPostgresPool(ctx, logger)
 		if err != nil {
 			return stores{}, nil, err
 		}
 		return stores{
-			players: storepostgres.NewPlayerStore(pool),
-			history: storepostgres.NewHistoryStore(pool),
+			players: storepostgres.NewPlayerStore(logger, pool),
+			history: storepostgres.NewHistoryStore(logger, pool),
 		}, func() { pool.Close() }, nil
 
 	default:
@@ -74,13 +75,13 @@ func openStores(ctx context.Context, kind string) (stores, func(), error) {
 
 // openPlayerFileStore will open or create a new json file to use as storage
 // behind the application
-func openPlayerFileStore() (types.PlayerStore, func(), error) {
+func openPlayerFileStore(logger *slog.Logger) (types.PlayerStore, func(), error) {
 	f, err := os.OpenFile(playerFileName, os.O_RDWR|os.O_CREATE, 0666)
 	if err != nil {
 		return nil, nil, fmt.Errorf("open %s: %w", playerFileName, err)
 	}
 
-	store, err := storefile.NewFileSystemPlayerStore(f)
+	store, err := storefile.NewFileSystemPlayerStore(logger, f)
 	if err != nil {
 		f.Close()
 		return nil, nil, fmt.Errorf("new file system player store: %w", err)
@@ -88,13 +89,13 @@ func openPlayerFileStore() (types.PlayerStore, func(), error) {
 	return store, func() { f.Close() }, nil
 }
 
-func openHistoryFileStore() (types.HistoryStore, func(), error) {
+func openHistoryFileStore(logger *slog.Logger) (types.HistoryStore, func(), error) {
 	f, err := os.OpenFile(historyFileName, os.O_RDWR|os.O_CREATE, 0666)
 	if err != nil {
 		return nil, nil, fmt.Errorf("open %s: %w", historyFileName, err)
 	}
 
-	store, err := storefile.NewFileSystemHistoryStore(f)
+	store, err := storefile.NewFileSystemHistoryStore(logger, f)
 	if err != nil {
 		f.Close()
 		return nil, nil, fmt.Errorf("new file system player store: %w", err)
@@ -104,7 +105,7 @@ func openHistoryFileStore() (types.HistoryStore, func(), error) {
 
 // ===========================
 
-func openPostgresPool(ctx context.Context) (*pgxpool.Pool, error) {
+func openPostgresPool(ctx context.Context, logger *slog.Logger) (*pgxpool.Pool, error) {
 	dsn := os.Getenv("DATABASE_URL")
 	if dsn == "" {
 		return nil, fmt.Errorf("DATABASE_URL is required for postgres store")
@@ -131,6 +132,6 @@ func openPostgresPool(ctx context.Context) (*pgxpool.Pool, error) {
 		return nil, fmt.Errorf("run migrations: %w", err)
 	}
 
-	fmt.Println("postgres: connected, migrations applied")
+	logger.Info("postgres connected, migrations applied")
 	return pool, nil
 }

--- a/internal/logging/log.go
+++ b/internal/logging/log.go
@@ -3,15 +3,37 @@ package logging
 import (
 	"io"
 	"log/slog"
-	"os"
+	"strings"
 )
 
-func New(w io.Writer) *slog.Logger {
-	return slog.New(slog.NewJSONHandler(w, &slog.HandlerOptions{
-		Level: slog.LevelInfo,
-	}))
+// New builds a slog.Logger writing to w, filtered at level, using the given
+// format. format is "text" (human-readable, the dev default) or "json"
+// (structured); anything else falls back to text.
+func New(w io.Writer, level slog.Level, format string) *slog.Logger {
+	opts := &slog.HandlerOptions{Level: level}
+
+	var h slog.Handler
+	switch strings.ToLower(format) {
+	case "json":
+		h = slog.NewJSONHandler(w, opts)
+	default:
+		h = slog.NewTextHandler(w, opts)
+	}
+
+	return slog.New(h)
 }
 
-func NewLogger() *slog.Logger {
-	return New(os.Stdout)
+// ParseLevel maps a config/flag string to a slog.Level. Unknown values default
+// to debug because the application runs verbose in development.
+func ParseLevel(s string) slog.Level {
+	switch strings.ToLower(s) {
+	case "info":
+		return slog.LevelInfo
+	case "warn", "warning":
+		return slog.LevelWarn
+	case "error":
+		return slog.LevelError
+	default:
+		return slog.LevelDebug
+	}
 }

--- a/internal/store/file/file-store.go
+++ b/internal/store/file/file-store.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"log/slog"
 	"os"
 
 	"github.com/google/uuid"
@@ -23,11 +24,12 @@ var seedPlayerID = uuid.MustParse("00000000-0000-0000-0000-000000000000")
 const HistoryFile = "history.db.json"
 
 type FileSystemHistoryStore struct {
+	logger   *slog.Logger
 	database *json.Encoder
 	history  types.History
 }
 
-func NewFileSystemHistoryStore(file *os.File) (*FileSystemHistoryStore, error) {
+func NewFileSystemHistoryStore(logger *slog.Logger, file *os.File) (*FileSystemHistoryStore, error) {
 	file.Seek(0, io.SeekStart)
 
 	err := initialiseHistoryDBFile(file)
@@ -40,7 +42,14 @@ func NewFileSystemHistoryStore(file *os.File) (*FileSystemHistoryStore, error) {
 		return nil, err
 	}
 
+	logger = logger.With(slog.String("component", "file-history-store"))
+	logger.Debug("opened history store",
+		slog.String("file", file.Name()),
+		slog.Int("history_len", len(history)),
+	)
+
 	return &FileSystemHistoryStore{
+		logger:   logger,
 		database: json.NewEncoder(&tape{file}),
 		history:  history,
 	}, nil
@@ -65,6 +74,10 @@ func (f *FileSystemHistoryStore) RecordInteraction(interaction types.Interaction
 		return fmt.Errorf("encoding history to file: %w", err)
 	}
 
+	f.logger.Debug("recorded interaction",
+		slog.String("id", interaction.ID.String()),
+		slog.Int("history_len", len(f.history)),
+	)
 	return nil
 }
 
@@ -82,11 +95,12 @@ func (f *FileSystemHistoryStore) GetHistoryByPlayerID(playerID uuid.UUID) (types
 // ==================
 
 type FileSystemStore struct {
+	logger   *slog.Logger
 	database *json.Encoder
 	players  types.Players
 }
 
-func NewFileSystemPlayerStore(file *os.File) (*FileSystemStore, error) {
+func NewFileSystemPlayerStore(logger *slog.Logger, file *os.File) (*FileSystemStore, error) {
 	file.Seek(0, io.SeekStart)
 
 	err := initialisePlayerDBFile(file)
@@ -99,7 +113,14 @@ func NewFileSystemPlayerStore(file *os.File) (*FileSystemStore, error) {
 		return nil, err
 	}
 
+	logger = logger.With(slog.String("component", "file-player-store"))
+	logger.Debug("opened player store",
+		slog.String("file", file.Name()),
+		slog.Int("player_count", len(players)),
+	)
+
 	store := &FileSystemStore{
+		logger:   logger,
 		database: json.NewEncoder(&tape{file}),
 		players:  players,
 	}
@@ -137,6 +158,10 @@ func (f *FileSystemStore) GetOrCreatePlayer(name string) (types.Player, error) {
 		return types.Player{}, fmt.Errorf("encoding players to file: %w", err)
 	}
 
+	f.logger.Debug("created player",
+		slog.String("name", newPlayer.Name),
+		slog.String("id", newPlayer.ID.String()),
+	)
 	return newPlayer, nil
 }
 

--- a/internal/store/file/file-store_integration_test.go
+++ b/internal/store/file/file-store_integration_test.go
@@ -11,7 +11,7 @@ func TestFileSystemPlayerStore_Contract(t *testing.T) {
 	testhelpers.RunPlayerStoreContract(t, func(t *testing.T) types.PlayerStore {
 		f, cleanup := createTempFile(t, "[]")
 		t.Cleanup(cleanup)
-		store, err := NewFileSystemPlayerStore(f)
+		store, err := NewFileSystemPlayerStore(testhelpers.NoopLogger(), f)
 		if err != nil {
 			t.Fatalf("could not create store: %v", err)
 		}
@@ -23,7 +23,7 @@ func TestFileSystemHistoryStore_Contract(t *testing.T) {
 	testhelpers.RunHistoryStoreContract(t, func(t *testing.T) types.HistoryStore {
 		f, cleanup := createTempFile(t, "[]")
 		t.Cleanup(cleanup)
-		store, err := NewFileSystemHistoryStore(f)
+		store, err := NewFileSystemHistoryStore(testhelpers.NoopLogger(), f)
 		if err != nil {
 			t.Fatalf("could not create store: %v", err)
 		}

--- a/internal/store/file/file-store_test.go
+++ b/internal/store/file/file-store_test.go
@@ -29,7 +29,7 @@ func TestFileSystemPlayerStore(t *testing.T) {
 	defer closer()
 
 	t.Run("get a player", func(t *testing.T) {
-		store, err := NewFileSystemPlayerStore(newTempStore)
+		store, err := NewFileSystemPlayerStore(testhelpers.NoopLogger(), newTempStore)
 		testhelpers.AssertNoError(t, err)
 
 		got, err := store.GetPlayerByID(player1)
@@ -45,7 +45,7 @@ func TestFileSystemPlayerStore(t *testing.T) {
 		database, cleanDatabase := createTempFile(t, "")
 		defer cleanDatabase()
 
-		_, err := NewFileSystemPlayerStore(database)
+		_, err := NewFileSystemPlayerStore(testhelpers.NoopLogger(), database)
 
 		testhelpers.AssertNoError(t, err)
 	})
@@ -54,13 +54,13 @@ func TestFileSystemPlayerStore(t *testing.T) {
 		database, cleanDatabase := createTempFile(t, "[]")
 		defer cleanDatabase()
 
-		store, err := NewFileSystemPlayerStore(database)
+		store, err := NewFileSystemPlayerStore(testhelpers.NoopLogger(), database)
 		testhelpers.AssertNoError(t, err)
 
 		created, err := store.GetOrCreatePlayer("Alice")
 		testhelpers.AssertNoError(t, err)
 
-		reopened, err := NewFileSystemPlayerStore(database)
+		reopened, err := NewFileSystemPlayerStore(testhelpers.NoopLogger(), database)
 		testhelpers.AssertNoError(t, err)
 
 		got, err := reopened.GetPlayerByName("Alice")
@@ -86,7 +86,7 @@ func TestFileSystemHistoryStore(t *testing.T) {
 	newTempStore, closer := createTempFile(t, goldenHistoryData)
 	defer closer()
 	t.Run("single interaction", func(t *testing.T) {
-		store, err := NewFileSystemHistoryStore(newTempStore)
+		store, err := NewFileSystemHistoryStore(testhelpers.NoopLogger(), newTempStore)
 		testhelpers.AssertNoError(t, err)
 
 		got, err := store.GetInteraction(interactionIDOne)
@@ -109,7 +109,7 @@ func TestFileSystemHistoryStore(t *testing.T) {
 		database, cleanDatabase := createTempFile(t, "")
 		defer cleanDatabase()
 
-		_, err := NewFileSystemPlayerStore(database)
+		_, err := NewFileSystemPlayerStore(testhelpers.NoopLogger(), database)
 
 		testhelpers.AssertNoError(t, err)
 	})

--- a/internal/store/memory/in-memory-store.go
+++ b/internal/store/memory/in-memory-store.go
@@ -1,6 +1,8 @@
 package memory
 
 import (
+	"log/slog"
+
 	"github.com/google/uuid"
 	"github.com/iancullinane/prisoner/internal/types"
 )
@@ -9,11 +11,15 @@ import (
 // ------------------------------------------------------------
 
 type InMemoryHistoryStore struct {
-	store []types.Interaction
+	logger *slog.Logger
+	store  []types.Interaction
 }
 
-func NewInMemoryHistoryStore() *InMemoryHistoryStore {
-	return &InMemoryHistoryStore{[]types.Interaction{}}
+func NewInMemoryHistoryStore(logger *slog.Logger) *InMemoryHistoryStore {
+	return &InMemoryHistoryStore{
+		logger: logger.With(slog.String("component", "memory-history-store")),
+		store:  []types.Interaction{},
+	}
 }
 
 func (i *InMemoryHistoryStore) GetHistory() (types.History, error) {
@@ -22,6 +28,10 @@ func (i *InMemoryHistoryStore) GetHistory() (types.History, error) {
 
 func (i *InMemoryHistoryStore) RecordInteraction(interaction types.Interaction) error {
 	i.store = append(i.store, interaction)
+	i.logger.Debug("recorded interaction",
+		slog.String("id", interaction.ID.String()),
+		slog.Int("history_len", len(i.store)),
+	)
 	return nil
 }
 
@@ -39,13 +49,15 @@ func (i *InMemoryHistoryStore) GetHistoryByPlayerID(playerID uuid.UUID) (types.H
 // ------------------------------------------------------------
 
 // in_memory_player_store.go
-func NewInMemoryPlayerStore() *InMemoryPlayerStore {
+func NewInMemoryPlayerStore(logger *slog.Logger) *InMemoryPlayerStore {
 	return &InMemoryPlayerStore{
+		logger:  logger.With(slog.String("component", "memory-player-store")),
 		players: types.Players{},
 	}
 }
 
 type InMemoryPlayerStore struct {
+	logger  *slog.Logger
 	players types.Players
 }
 
@@ -57,6 +69,10 @@ func (i *InMemoryPlayerStore) GetOrCreatePlayer(name string) (types.Player, erro
 
 	newPlayer := types.NewPlayer(name)
 	i.players = append(i.players, *newPlayer)
+	i.logger.Debug("created player",
+		slog.String("name", newPlayer.Name),
+		slog.String("id", newPlayer.ID.String()),
+	)
 	return *newPlayer, nil
 }
 

--- a/internal/store/memory/in-memory-store_test.go
+++ b/internal/store/memory/in-memory-store_test.go
@@ -11,12 +11,12 @@ import (
 // =========================================
 func TestInMemoryPlayerStore_Contract(t *testing.T) {
 	testhelpers.RunPlayerStoreContract(t, func(t *testing.T) types.PlayerStore {
-		return NewInMemoryPlayerStore()
+		return NewInMemoryPlayerStore(testhelpers.NoopLogger())
 	})
 }
 
 func TestInMemoryHistoryStore_Contract(t *testing.T) {
 	testhelpers.RunHistoryStoreContract(t, func(t *testing.T) types.HistoryStore {
-		return NewInMemoryHistoryStore()
+		return NewInMemoryHistoryStore(testhelpers.NoopLogger())
 	})
 }

--- a/internal/store/postgres/postgres-store.go
+++ b/internal/store/postgres/postgres-store.go
@@ -3,6 +3,7 @@ package postgres
 import (
 	"context"
 	"fmt"
+	"log/slog"
 
 	"github.com/google/uuid"
 	"github.com/jackc/pgx/v5/pgtype"
@@ -14,12 +15,17 @@ import (
 )
 
 type HistoryStore struct {
-	pool *pgxpool.Pool
-	q    *sqlcdb.Queries
+	logger *slog.Logger
+	pool   *pgxpool.Pool
+	q      *sqlcdb.Queries
 }
 
-func NewHistoryStore(pool *pgxpool.Pool) *HistoryStore {
-	return &HistoryStore{pool: pool, q: sqlcdb.New(pool)}
+func NewHistoryStore(logger *slog.Logger, pool *pgxpool.Pool) *HistoryStore {
+	return &HistoryStore{
+		logger: logger.With(slog.String("component", "postgres-history-store")),
+		pool:   pool,
+		q:      sqlcdb.New(pool),
+	}
 }
 
 // interaction from row
@@ -57,6 +63,9 @@ func (s *HistoryStore) RecordInteraction(interaction types.Interaction) error {
 	if err := s.q.RecordInteraction(ctx, params); err != nil {
 		return err
 	}
+	s.logger.Debug("recorded interaction",
+		slog.String("id", interaction.ID.String()),
+	)
 	return nil
 }
 
@@ -75,12 +84,17 @@ func (s *HistoryStore) GetHistoryByPlayerID(playerID uuid.UUID) (types.History, 
 }
 
 type PlayerStore struct {
-	pool *pgxpool.Pool
-	q    *sqlcdb.Queries
+	logger *slog.Logger
+	pool   *pgxpool.Pool
+	q      *sqlcdb.Queries
 }
 
-func NewPlayerStore(pool *pgxpool.Pool) *PlayerStore {
-	return &PlayerStore{pool: pool, q: sqlcdb.New(pool)}
+func NewPlayerStore(logger *slog.Logger, pool *pgxpool.Pool) *PlayerStore {
+	return &PlayerStore{
+		logger: logger.With(slog.String("component", "postgres-player-store")),
+		pool:   pool,
+		q:      sqlcdb.New(pool),
+	}
 }
 
 func playerFromRow(p sqlcdb.Player) types.Player {
@@ -97,7 +111,12 @@ func (s *PlayerStore) GetOrCreatePlayer(name string) (types.Player, error) {
 		return types.Player{}, fmt.Errorf("get or create player %q: %w", name, err)
 	}
 
-	return playerFromRow(player), nil
+	out := playerFromRow(player)
+	s.logger.Debug("get or create player",
+		slog.String("name", out.Name),
+		slog.String("id", out.ID.String()),
+	)
+	return out, nil
 }
 
 func (s *PlayerStore) GetPlayerByID(id uuid.UUID) (types.Player, error) {

--- a/internal/store/postgres/postgres_integration_test.go
+++ b/internal/store/postgres/postgres_integration_test.go
@@ -74,7 +74,7 @@ func TestPostgresPlayerStore_Contract(t *testing.T) {
 		if _, err := integrationPool.Exec(context.Background(), "TRUNCATE players CASCADE"); err != nil {
 			t.Fatalf("could not truncate players table: %v", err)
 		}
-		return NewPlayerStore(integrationPool)
+		return NewPlayerStore(testhelpers.NoopLogger(), integrationPool)
 	})
 }
 
@@ -88,7 +88,7 @@ func TestPostgresHistoryStore_Contract(t *testing.T) {
 		if err := seedTestPlayers(ctx, integrationPool); err != nil {
 			t.Fatalf("seed test players: %v", err)
 		}
-		return NewHistoryStore(integrationPool)
+		return NewHistoryStore(testhelpers.NoopLogger(), integrationPool)
 	})
 }
 

--- a/internal/store/testhelpers/testhelpers.go
+++ b/internal/store/testhelpers/testhelpers.go
@@ -1,6 +1,7 @@
 package testhelpers
 
 import (
+	"log/slog"
 	"reflect"
 	"testing"
 
@@ -8,6 +9,12 @@ import (
 	"github.com/iancullinane/prisoner/internal/types"
 	"github.com/iancullinane/prisoner/pkg/prisoner"
 )
+
+// NoopLogger returns a logger that discards all output, for store constructors
+// under test where log output is not the thing being asserted.
+func NoopLogger() *slog.Logger {
+	return slog.New(slog.DiscardHandler)
+}
 
 const (
 	TestPlayerOne     = "00000000-0000-0000-0000-000000000000"


### PR DESCRIPTION
This pull request introduces a unified and configurable logging system across the CLI, server, and all storage backends. It replaces previous ad-hoc logging with a structured approach using `slog`, allowing log level and format to be set via command-line flags or configuration. Store constructors and server components now accept a logger, which is propagated throughout the application for consistent, contextual logging. Additionally, a new CLI subcommand for player operations is added.

**Logging System Overhaul**

* Introduced a process-wide `logger` variable in `cmd/root.go`, initialized in `PersistentPreRunE` based on config/flags for log level and format, using the new `logging.New` and `logging.ParseLevel` functions. All subcommands and stores now derive their loggers from this root logger. [[1]](diffhunk://#diff-ab967ab1a2f3a1b769106eeb7bfe892ef0e81d1d27811fa15be08e6749feee1fR8-R22) [[2]](diffhunk://#diff-ab967ab1a2f3a1b769106eeb7bfe892ef0e81d1d27811fa15be08e6749feee1fR43-R54) [[3]](diffhunk://#diff-ab967ab1a2f3a1b769106eeb7bfe892ef0e81d1d27811fa15be08e6749feee1fR72-R76) [[4]](diffhunk://#diff-ab967ab1a2f3a1b769106eeb7bfe892ef0e81d1d27811fa15be08e6749feee1fR102-R103) [[5]](diffhunk://#diff-f865a10313dd3abdaf7f263bfedc892eb1f6159f9fcd6482b67c59cc512e7ad8L6-R38)
* Refactored the `openStores` function and related store constructors to accept a `*slog.Logger` parameter, ensuring all storage backends (memory, file, postgres) use consistent, contextual logging. [[1]](diffhunk://#diff-559477cd08116fa690483e9d745d3d5e89cf1e1ad77492cc8c2388f2ca810ca4R6) [[2]](diffhunk://#diff-559477cd08116fa690483e9d745d3d5e89cf1e1ad77492cc8c2388f2ca810ca4L36-R50) [[3]](diffhunk://#diff-559477cd08116fa690483e9d745d3d5e89cf1e1ad77492cc8c2388f2ca810ca4L58-R65) [[4]](diffhunk://#diff-559477cd08116fa690483e9d745d3d5e89cf1e1ad77492cc8c2388f2ca810ca4L77-R98) [[5]](diffhunk://#diff-559477cd08116fa690483e9d745d3d5e89cf1e1ad77492cc8c2388f2ca810ca4L107-R108) [[6]](diffhunk://#diff-559477cd08116fa690483e9d745d3d5e89cf1e1ad77492cc8c2388f2ca810ca4L134-R135) [[7]](diffhunk://#diff-77d333b91263a20bcda517fce85ab2e2ae7653c15f05c8ab87f283adbc1e7c7fL43-R43)
* Updated file-based and postgres stores to log key lifecycle events (e.g., opening stores, creating players, recording interactions) with context-rich debug messages. [[1]](diffhunk://#diff-ee065e99167822a5707b325ee66314676de30b7f1015b15276ab1d18704073b5R8) [[2]](diffhunk://#diff-ee065e99167822a5707b325ee66314676de30b7f1015b15276ab1d18704073b5R27-R32) [[3]](diffhunk://#diff-ee065e99167822a5707b325ee66314676de30b7f1015b15276ab1d18704073b5R45-R52) [[4]](diffhunk://#diff-ee065e99167822a5707b325ee66314676de30b7f1015b15276ab1d18704073b5R77-R80) [[5]](diffhunk://#diff-ee065e99167822a5707b325ee66314676de30b7f1015b15276ab1d18704073b5R98-R103) [[6]](diffhunk://#diff-ee065e99167822a5707b325ee66314676de30b7f1015b15276ab1d18704073b5R116-R123) [[7]](diffhunk://#diff-ee065e99167822a5707b325ee66314676de30b7f1015b15276ab1d18704073b5R161-R164)

**CLI and Server Integration**

* Modified all CLI commands (`server`, `simulate`, and the new `player` command) to use the shared logger and pass it to stores and servers, ensuring uniform log output and configuration. [[1]](diffhunk://#diff-ee2560d627cd77f1563972217a33ac39a4bf56fbf30d7f560fbb4199b9f70197L8-L13) [[2]](diffhunk://#diff-ee2560d627cd77f1563972217a33ac39a4bf56fbf30d7f560fbb4199b9f70197L25-R35) [[3]](diffhunk://#diff-77d333b91263a20bcda517fce85ab2e2ae7653c15f05c8ab87f283adbc1e7c7fL43-R43) [[4]](diffhunk://#diff-77d333b91263a20bcda517fce85ab2e2ae7653c15f05c8ab87f283adbc1e7c7fL57) [[5]](diffhunk://#diff-1e8ef84ccd86491f1d5fcc4a3398854fb26d91ab62b10a2a8f136e10d12dd94eR1-R64)

**Testing and Utilities**

* Updated server and store tests to use a test logger that discards output, decoupling test assertions from log output. [[1]](diffhunk://#diff-07ac88307c7152abb59f1785cf3b212943b20acc682441ff589f4af89237359fR7-R20) [[2]](diffhunk://#diff-07ac88307c7152abb59f1785cf3b212943b20acc682441ff589f4af89237359fL40-R43) [[3]](diffhunk://#diff-07ac88307c7152abb59f1785cf3b212943b20acc682441ff589f4af89237359fL90-R93) [[4]](diffhunk://#diff-07ac88307c7152abb59f1785cf3b212943b20acc682441ff589f4af89237359fL138-R141) [[5]](diffhunk://#diff-07ac88307c7152abb59f1785cf3b212943b20acc682441ff589f4af89237359fL200-R203) [[6]](diffhunk://#diff-3f6617ea89fb780222aaf7fb00ad8aca1f837556894c7b16869787459fdb54c1L14-R14)

**New Features**

* Added a new `player` CLI subcommand to retrieve player information from the configured store, demonstrating use of the new logger and store initialization pattern.This was helped with Claude/ Threads a logging object to everywhere including stores.