### PR TITLE
Add migrate command and remove migration from server startup

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -12,8 +12,9 @@ RUN apk add --no-cache ca-certificates
 
 WORKDIR /app
 COPY --from=build /prisoner /app/prisoner
+COPY docker-entrypoint.sh /app/docker-entrypoint.sh
+RUN chmod +x /app/docker-entrypoint.sh
 
 EXPOSE 5001
 
-ENTRYPOINT ["/app/prisoner"]
-CMD ["-server"]
+ENTRYPOINT ["/app/docker-entrypoint.sh"]

--- a/cmd/migrate.go
+++ b/cmd/migrate.go
@@ -1,0 +1,95 @@
+/*
+Copyright © 2026 NAME HERE <EMAIL ADDRESS>
+*/
+package cmd
+
+import (
+    "context"
+    "fmt"
+    "log/slog"
+    "os"
+
+    "database/sql"
+
+    "github.com/iancullinane/prisoner/db"
+    "github.com/jackc/pgx/v5/pgxpool"
+    "github.com/jackc/pgx/v5/stdlib"
+    "github.com/pressly/goose/v3"
+    "github.com/spf13/cobra"
+)
+
+var migrateCmd = &cobra.Command{
+    Use:   "migrate",
+    Short: "Database migration commands",
+    Long:  `Run database migrations up, down, or check status`,
+}
+
+var migrateUpCmd = &cobra.Command{
+    Use:   "up",
+    Short: "Run all pending migrations",
+    RunE: func(cmd *cobra.Command, args []string) error {
+        return runMigration(func(stdDB *sql.DB) error {
+            return goose.Up(stdDB, "migrations")
+        })
+    },
+}
+
+var migrateDownCmd = &cobra.Command{
+    Use:   "down",
+    Short: "Roll back the last migration",
+    RunE: func(cmd *cobra.Command, args []string) error {
+        return runMigration(func(stdDB *sql.DB) error {
+            return goose.Down(stdDB, "migrations")
+        })
+    },
+}
+
+var migrateStatusCmd = &cobra.Command{
+    Use:   "status",
+    Short: "Show migration status",
+    RunE: func(cmd *cobra.Command, args []string) error {
+        return runMigration(func(stdDB *sql.DB) error {
+            return goose.Status(stdDB, "migrations")
+        })
+    },
+}
+
+func runMigration(fn func(*sql.DB) error) error {
+    ctx := context.Background()
+    log := logger.With(slog.String("service", "migrate"))
+
+    dsn := os.Getenv("DATABASE_URL")
+    if dsn == "" {
+        return fmt.Errorf("DATABASE_URL is required")
+    }
+
+    pool, err := pgxpool.New(ctx, dsn)
+    if err != nil {
+        return fmt.Errorf("connect to database: %w", err)
+    }
+    defer pool.Close()
+
+    if err := pool.Ping(ctx); err != nil {
+        return fmt.Errorf("ping database: %w", err)
+    }
+
+    stdDB := stdlib.OpenDBFromPool(pool)
+    defer stdDB.Close()
+
+    goose.SetBaseFS(db.Migrations)
+    goose.SetDialect("postgres")
+
+    if err := fn(stdDB); err != nil {
+        return fmt.Errorf("migration failed: %w", err)
+    }
+
+    log.Info("migration completed successfully")
+    return nil
+}
+
+func init() {
+    rootCmd.AddCommand(migrateCmd)
+    migrateCmd.AddCommand(migrateUpCmd)
+    migrateCmd.AddCommand(migrateDownCmd)
+    migrateCmd.AddCommand(migrateStatusCmd)
+}

--- a/cmd/store-opener.go
+++ b/cmd/store-opener.go
@@ -6,14 +6,11 @@ import (
 	"log/slog"
 	"os"
 
-	"github.com/iancullinane/prisoner/db"
-	storefile "github.com/iancullinane/prisoner/internal/store/file"
-	"github.com/iancullinane/prisoner/internal/store/memory"
-	storepostgres "github.com/iancullinane/prisoner/internal/store/postgres"
-	"github.com/iancullinane/prisoner/internal/types"
-	"github.com/jackc/pgx/v5/pgxpool"
-	"github.com/jackc/pgx/v5/stdlib"
-	"github.com/pressly/goose/v3"
+    storefile "github.com/iancullinane/prisoner/internal/store/file"
+    "github.com/iancullinane/prisoner/internal/store/memory"
+    storepostgres "github.com/iancullinane/prisoner/internal/store/postgres"
+    "github.com/iancullinane/prisoner/internal/types"
+    "github.com/jackc/pgx/v5/pgxpool"
 )
 
 const (
@@ -116,22 +113,11 @@ func openPostgresPool(ctx context.Context, logger *slog.Logger) (*pgxpool.Pool, 
 		return nil, err
 	}
 
-	if err := pool.Ping(ctx); err != nil {
-		pool.Close()
-		return nil, fmt.Errorf("postgres ping: %w", err)
-	}
+    if err := pool.Ping(ctx); err != nil {
+        pool.Close()
+        return nil, fmt.Errorf("postgres ping: %w", err)
+    }
 
-	// needed for goose
-	stdDB := stdlib.OpenDBFromPool(pool)
-
-	// this is kind of the 'explicit' bit needed to use the embedded migrations
-	goose.SetBaseFS(db.Migrations)
-	goose.SetDialect("postgres")
-	if err := goose.Up(stdDB, "migrations"); err != nil {
-		pool.Close()
-		return nil, fmt.Errorf("run migrations: %w", err)
-	}
-
-	logger.Info("postgres connected, migrations applied")
-	return pool, nil
+    logger.Info("postgres connected")
+    return pool, nil
 }

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -1,0 +1,8 @@
+#!/bin/sh
+set -e
+
+echo "Running database migrations..."
+/app/prisoner migrate up
+
+echo "Starting server..."
+exec /app/prisoner server


### PR DESCRIPTION
This pull request introduces a dedicated database migration command and refactors how migrations are handled during application startup. The migration logic is moved out of the database connection code and into a new CLI command, and the Docker entrypoint is updated to ensure migrations run before the server starts.

**Database migration improvements:**

* Added a new `migrate` command (`cmd/migrate.go`) with subcommands (`up`, `down`, `status`) for managing database migrations using Goose, and moved all migration logic into this command.
* Removed migration logic from the Postgres connection setup in `cmd/store-opener.go`, so opening a database connection no longer triggers migrations.
* Cleaned up unused imports related to migrations in `cmd/store-opener.go`.

**Docker and startup process changes:**

* Added a new `docker-entrypoint.sh` script that runs database migrations before starting the server, and updated the Dockerfile to use this script as the entrypoint. [[1]](diffhunk://#diff-79738685a656fe6b25061bb14181442210b599f746faeaba408a2401de45038aR1-R8) [[2]](diffhunk://#diff-dd2c0eb6ea5cfc6c4bd4eac30934e2d5746747af48fef6da689e85b752f39557R15-R20)