### PR TITLE
Rename to PlayedAt and add internal interaction tests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -39,6 +39,8 @@ test-integration-file:
 test-integration-postgres:
 	go test -v -tags=integration -count=1 -timeout=10m ./internal/store/postgres/...
 
-run-server-postgres: build compose-up
+start-db: compose-up
 	@until docker compose exec -T db pg_isready -U prisoner -d prisoner >/dev/null 2>&1; do sleep 0.3; done
+
+run-server-postgres: build start-db
 	DATABASE_URL='postgres://prisoner:prisoner@127.0.0.1:5432/prisoner?sslmode=disable' ./bin/prisoner --store postgres server

--- a/internal/store/postgres/postgres-store.go
+++ b/internal/store/postgres/postgres-store.go
@@ -36,6 +36,7 @@ func interactionFromRow(i sqlcdb.Interaction) types.Interaction {
 		PlayerB:     i.PlayerBID.Bytes,
 		PlayerAMove: prisoner.Move([]rune(i.PlayerAMove)[0]),
 		PlayerBMove: prisoner.Move([]rune(i.PlayerBMove)[0]),
+		PlayedAt:    i.PlayedAt.Time,
 	}
 }
 
@@ -59,6 +60,7 @@ func (s *HistoryStore) RecordInteraction(interaction types.Interaction) error {
 		PlayerBID:   pgtype.UUID{Bytes: interaction.PlayerB, Valid: true},
 		PlayerAMove: string(interaction.PlayerAMove),
 		PlayerBMove: string(interaction.PlayerBMove),
+		PlayedAt:    pgtype.Timestamptz{Time: interaction.PlayedAt, Valid: true},
 	}
 	if err := s.q.RecordInteraction(ctx, params); err != nil {
 		return err

--- a/internal/store/testhelpers/testhelpers.go
+++ b/internal/store/testhelpers/testhelpers.go
@@ -4,6 +4,7 @@ import (
 	"log/slog"
 	"reflect"
 	"testing"
+	"time"
 
 	"github.com/google/uuid"
 	"github.com/iancullinane/prisoner/internal/types"
@@ -92,6 +93,26 @@ func RunHistoryStoreContract(t *testing.T, newStore func(t *testing.T) types.His
 			t.Errorf("got player b move %v, want %v", history[0].PlayerBMove, move2)
 		}
 
+	})
+
+	t.Run("interaction played_at round-trips", func(t *testing.T) {
+		store := newStore(t)
+		recorded := mustRecordInteraction(t, store, TestPlayerOneID, TestPlayerTwoID, prisoner.Cooperate, prisoner.Cooperate)
+
+		history := mustGetHistory(t, store)
+		if len(history) != 1 {
+			t.Fatalf("got %d interactions, want 1", len(history))
+		}
+
+		got := history[0].PlayedAt
+		if got.IsZero() {
+			t.Fatalf("got zero PlayedAt, want it to round-trip")
+		}
+		// Postgres stores timestamptz at microsecond precision; truncate so the
+		// comparison holds across all backends. Equal ignores location (UTC vs local).
+		if !got.Truncate(time.Microsecond).Equal(recorded.PlayedAt.Truncate(time.Microsecond)) {
+			t.Errorf("got PlayedAt %v, want %v", got, recorded.PlayedAt)
+		}
 	})
 
 	t.Run("history of unknown player is empty list", func(t *testing.T) {
@@ -215,12 +236,13 @@ func assertPlayerNotFound(t testing.TB, err error) {
 	}
 }
 
-func mustRecordInteraction(t *testing.T, store types.HistoryStore, player1, player2 uuid.UUID, move1, move2 prisoner.Move) {
+func mustRecordInteraction(t *testing.T, store types.HistoryStore, player1, player2 uuid.UUID, move1, move2 prisoner.Move) types.Interaction {
 	t.Helper()
 	interaction := types.NewInteraction(player1, player2, move1, move2)
 	if err := store.RecordInteraction(interaction); err != nil {
 		t.Fatalf("RecordInteraction(%v) returned error: %v", interaction, err)
 	}
+	return interaction
 }
 
 func mustGetHistory(t *testing.T, store types.HistoryStore) types.History {

--- a/internal/types/interaction.go
+++ b/internal/types/interaction.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
+	"time"
 
 	"github.com/google/uuid"
 	"github.com/iancullinane/prisoner/pkg/prisoner"
@@ -34,7 +35,7 @@ type Interaction struct {
 	PlayerB     uuid.UUID
 	PlayerAMove prisoner.Move
 	PlayerBMove prisoner.Move
-	// CreatedAt       time.Time
+	PlayedAt    time.Time
 }
 
 func NewInteraction(playerA, playerB uuid.UUID, playerAMove, playerBMove prisoner.Move) Interaction {
@@ -44,7 +45,7 @@ func NewInteraction(playerA, playerB uuid.UUID, playerAMove, playerBMove prisone
 		PlayerB:     playerB,
 		PlayerAMove: playerAMove,
 		PlayerBMove: playerBMove,
-		// CreatedAt:       time.Now(),
+		PlayedAt:    time.Now(),
 	}
 }
 

--- a/internal/types/interaction_test.go
+++ b/internal/types/interaction_test.go
@@ -1,0 +1,22 @@
+package types
+
+import (
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/iancullinane/prisoner/pkg/prisoner"
+)
+
+func TestNewInteractionSetsPlayedAt(t *testing.T) {
+	before := time.Now()
+	interaction := NewInteraction(uuid.New(), uuid.New(), prisoner.Cooperate, prisoner.Betray)
+	after := time.Now()
+
+	if interaction.PlayedAt.IsZero() {
+		t.Fatal("expected PlayedAt to be set, got zero value")
+	}
+	if interaction.PlayedAt.Before(before) || interaction.PlayedAt.After(after) {
+		t.Errorf("expected PlayedAt within [%v, %v], got %v", before, after, interaction.PlayedAt)
+	}
+}


### PR DESCRIPTION
This pull request introduces support for tracking when each interaction was played by adding a `PlayedAt` timestamp to the `Interaction` type. It ensures this timestamp is set when creating new interactions, persists it in the Postgres store, and verifies correct round-tripping and precision in tests.

**Interaction timestamp support:**

* Added a `PlayedAt` field of type `time.Time` to the `Interaction` struct in `internal/types/interaction.go`, and ensured it is set to the current time in `NewInteraction`. [[1]](diffhunk://#diff-8a4bd9323d2c5a09c3c87f47691a2766faf9fca43fa54af90b5fb780349dcebeL37-R38) [[2]](diffhunk://#diff-8a4bd9323d2c5a09c3c87f47691a2766faf9fca43fa54af90b5fb780349dcebeL47-R48)
* Added a unit test `TestNewInteractionSetsPlayedAt` to verify that `PlayedAt` is correctly set when creating a new interaction.

**Persistence and retrieval in Postgres store:**

* Modified `internal/store/postgres/postgres-store.go` to store and retrieve the `PlayedAt` timestamp when recording and fetching interactions. [[1]](diffhunk://#diff-bb4f22c854c6b81205a4dc38b9c0da0e75ffcfe2bb8488a2b42f21fe1159cd8fR39) [[2]](diffhunk://#diff-bb4f22c854c6b81205a4dc38b9c0da0e75ffcfe2bb8488a2b42f21fe1159cd8fR63)

**Testing and test helpers:**

* Updated test helpers in `internal/store/testhelpers/testhelpers.go` to return the recorded interaction, and added a test to confirm that `PlayedAt` round-trips correctly (including handling microsecond precision differences across backends). [[1]](diffhunk://#diff-51ca03bb43cbf5b709ef26c476aa5d1fcd289b2a8176b2071a3749f751efb166R98-R117) [[2]](diffhunk://#diff-51ca03bb43cbf5b709ef26c476aa5d1fcd289b2a8176b2071a3749f751efb166L218-R245) [[3]](diffhunk://#diff-51ca03bb43cbf5b709ef26c476aa5d1fcd289b2a8176b2071a3749f751efb166R7)

**Makefile improvements:**

* Refactored the Makefile to separate database startup logic into a `start-db` target, making the workflow for running the server with Postgres clearer and more robust.