### PR TITLE
Icullinane/add created at to player

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -40,6 +40,11 @@ jobs:
           plugins: 'code-review@claude-code-plugins'
           prompt: '/code-review:code-review ${{ github.repository }}/pull/${{ github.event.pull_request.number }}'
           allowed_bots: '*'
+          # Repo's .claude/settings.json only allowlists `go build`/`go test` for local
+          # interactive use; CI has no human to approve prompts, so anything outside
+          # that allowlist gets silently denied. Grant the tools needed to actually
+          # post review feedback.
+          claude_args: '--allowed-tools mcp__github_inline_comment__create_inline_comment,mcp__github_comment__update_claude_comment,Bash(gh pr *)'
           # See https://github.com/anthropics/claude-code-action/blob/main/docs/usage.md
           # or https://code.claude.com/docs/en/cli-reference for available options
 

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -43,8 +43,9 @@ jobs:
           # Optional: Give a custom prompt to Claude. If this is not specified, Claude will perform the instructions specified in the comment that tagged it.
           # prompt: 'Update the pull request description to include a summary of changes.'
 
-          # Optional: Add claude_args to customize behavior and configuration
-          # See https://github.com/anthropics/claude-code-action/blob/main/docs/usage.md
-          # or https://code.claude.com/docs/en/cli-reference for available options
-          # claude_args: '--allowed-tools Bash(gh pr *)'
+          # Repo's .claude/settings.json only allowlists `go build`/`go test` for local
+          # interactive use; CI has no human to approve prompts, so anything outside
+          # that allowlist gets silently denied. Grant the tools needed for Claude to
+          # actually respond to @claude mentions.
+          claude_args: '--allowed-tools mcp__github_comment__update_claude_comment,mcp__github_inline_comment__create_inline_comment,Bash(gh pr *),Bash(gh issue *)'
 

--- a/cmd/player.go
+++ b/cmd/player.go
@@ -27,6 +27,7 @@ var playerCmd = &cobra.Command{
 	Args:  cobra.MaximumNArgs(1),
 	RunE: func(cmd *cobra.Command, args []string) error {
 		storeKind := viper.GetString("store")
+		logger.Info(fmt.Sprintf("Using %s store", storeKind))
 
 		// set stores, one for players and one for history
 		st, cleanup, err := openStores(context.Background(), storeKind, logger)
@@ -62,7 +63,6 @@ var playerCmd = &cobra.Command{
 		if asJSON {
 			return printJSON(player)
 		}
-		fmt.Printf("Using %s store for player %q\n", storeKind, arg)
 		fmt.Printf("Player: %+v\n", player)
 
 		return nil


### PR DESCRIPTION
This pull request introduces several improvements to the CI workflow configuration and enhances logging in the `player` command. The main focus is on ensuring that the required tools are explicitly allowed for Claude automation in CI, and on improving the clarity of log output in the CLI.

**CI workflow configuration updates:**

* [`.github/workflows/claude.yml`](diffhunk://#diff-53fec9c265fdba82268df5cd90315b8da57cce43d8e20efbf5c0bdcd1de1342eL46-R50): Explicitly sets `claude_args` to allow the necessary tools for Claude to respond to `@claude` mentions in CI, including updating comments and creating inline comments. This ensures that Claude automation works as intended in CI environments where the default allowlist is restrictive.
* [`.github/workflows/claude-code-review.yml`](diffhunk://#diff-27456786e30ce9b1fa39c43f4e26f41177ee995f0a650d6d5aba7a826efbfe30R43-R47): Adds `claude_args` to grant the tools required for posting review feedback, addressing issues where CI prompts would otherwise be denied due to allowlist restrictions.

**Logging improvements in the player command:**

* [`cmd/player.go`](diffhunk://#diff-1e8ef84ccd86491f1d5fcc4a3398854fb26d91ab62b10a2a8f136e10d12dd94eR30): Adds a log line to clearly indicate which store backend is being used when running the player command, improving debuggability.
* [`cmd/player.go`](diffhunk://#diff-1e8ef84ccd86491f1d5fcc4a3398854fb26d91ab62b10a2a8f136e10d12dd94eL65): Removes a redundant `fmt.Printf` statement that duplicated information now logged via the logger, resulting in cleaner output.