### PR TITLE
Add integration tests to CI pipeline and enforce ECR push

### DIFF
--- a/.github/workflows/build-and-test.yaml
+++ b/.github/workflows/build-and-test.yaml
@@ -28,3 +28,24 @@ jobs:
 
       - name: Test
         run: go test ./...
+
+  integration-test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Go
+        uses: actions/setup-go@v5
+        with:
+          go-version-file: go.mod
+
+      - name: Set up sqlc
+        uses: sqlc-dev/setup-sqlc@v4
+        with:
+          sqlc-version: "1.31.1"
+
+      - name: Generate sqlc
+        run: sqlc generate
+
+      - name: Integration test
+        run: make test-integration

--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -44,7 +44,7 @@ jobs:
           # interactive use; CI has no human to approve prompts, so anything outside
           # that allowlist gets silently denied. Grant the tools needed to actually
           # post review feedback.
-          claude_args: '--allowed-tools mcp__github_inline_comment__create_inline_comment,mcp__github_comment__update_claude_comment,Bash(gh pr *)'
+          claude_args: '--allowed-tools "mcp__github_inline_comment__create_inline_comment,mcp__github_comment__update_claude_comment,Bash(gh pr *)"'
           # See https://github.com/anthropics/claude-code-action/blob/main/docs/usage.md
           # or https://code.claude.com/docs/en/cli-reference for available options
 

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -47,5 +47,5 @@ jobs:
           # interactive use; CI has no human to approve prompts, so anything outside
           # that allowlist gets silently denied. Grant the tools needed for Claude to
           # actually respond to @claude mentions.
-          claude_args: '--allowed-tools mcp__github_comment__update_claude_comment,mcp__github_inline_comment__create_inline_comment,Bash(gh pr *),Bash(gh issue *)'
+          claude_args: '--allowed-tools "mcp__github_comment__update_claude_comment,mcp__github_inline_comment__create_inline_comment,Bash(gh pr *),Bash(gh issue *)"'
 

--- a/.github/workflows/ecr-publish.yaml
+++ b/.github/workflows/ecr-publish.yaml
@@ -1,0 +1,67 @@
+name: Build and Push to ECR
+
+on:
+  push:
+    branches:
+      - main
+    tags:
+      - 'v*'
+  workflow_dispatch:
+
+env:
+  AWS_REGION: us-east-2
+  ECR_REPOSITORY: prisoner
+
+jobs:
+  build-and-push:
+    name: Build and Push Docker Image
+    runs-on: ubuntu-latest
+    permissions:
+      id-token: write
+      contents: read
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          role-to-assume: ${{ secrets.AWS_ROLE_TO_ASSUME }}
+          aws-region: ${{ env.AWS_REGION }}
+
+      - name: Login to Amazon ECR
+        id: login-ecr
+        uses: aws-actions/amazon-ecr-login@v2
+
+      - name: Extract metadata
+        id: meta
+        run: |
+          # Generate tags based on git ref
+          if [[ $GITHUB_REF == refs/tags/* ]]; then
+            VERSION=${GITHUB_REF#refs/tags/}
+            echo "tags=${{ steps.login-ecr.outputs.registry }}/${{ env.ECR_REPOSITORY }}:${VERSION},${{ steps.login-ecr.outputs.registry }}/${{ env.ECR_REPOSITORY }}:latest" >> $GITHUB_OUTPUT
+          else
+            SHORT_SHA=$(git rev-parse --short HEAD)
+            echo "tags=${{ steps.login-ecr.outputs.registry }}/${{ env.ECR_REPOSITORY }}:${SHORT_SHA},${{ steps.login-ecr.outputs.registry }}/${{ env.ECR_REPOSITORY }}:latest" >> $GITHUB_OUTPUT
+          fi
+
+      - name: Build Docker image
+        run: |
+          docker build -t prisoner:local .
+
+      - name: Tag and push Docker image
+        env:
+          TAGS: ${{ steps.meta.outputs.tags }}
+        run: |
+          IFS=',' read -ra TAG_ARRAY <<< "$TAGS"
+          for tag in "${TAG_ARRAY[@]}"; do
+            echo "Tagging and pushing: $tag"
+            docker tag prisoner:local "$tag"
+            docker push "$tag"
+          done
+
+      - name: Image digest
+        run: |
+          echo "Image pushed successfully!"
+          echo "Tags: ${{ steps.meta.outputs.tags }}"

--- a/internal/types/player.go
+++ b/internal/types/player.go
@@ -13,8 +13,6 @@ import (
 	"github.com/google/uuid"
 )
 
-const devPlayerName = "Steve"
-
 var (
 	ErrPlayerNotFound       = errors.New("player not found")
 	ErrCouldNotCreatePlayer = errors.New("could not create player")


### PR DESCRIPTION
This pull request introduces significant improvements to the CI/CD pipeline by adding integration testing to the existing workflow and creating a new workflow for building and pushing Docker images to AWS ECR. These changes enhance the project's automation, testing coverage, and deployment capabilities.

**CI/CD Workflow Enhancements:**

* Added a new `integration-test` job to `.github/workflows/build-and-test.yaml` that sets up Go and sqlc, generates code, and runs integration tests to ensure end-to-end functionality.
* Introduced a new workflow `.github/workflows/ecr-publish.yaml` that automates building, tagging, and pushing Docker images to AWS ECR on pushes to `main`, tag creation, or manual dispatch. This workflow handles AWS authentication, dynamic tagging based on Git refs, and image publishing.

**Code Cleanup:**

* Removed the unused `devPlayerName` constant from `internal/types/player.go` to clean up the codebase.