### PR TITLE
Enable ARM and AMD builds in GitHub Actions

### DIFF
--- a/.github/workflows/ecr-publish.yaml
+++ b/.github/workflows/ecr-publish.yaml
@@ -43,20 +43,24 @@ jobs:
             echo "tags=${{ steps.login-ecr.outputs.registry }}/${{ env.ECR_REPOSITORY }}:${SHORT_SHA},${{ steps.login-ecr.outputs.registry }}/${{ env.ECR_REPOSITORY }}:latest" >> $GITHUB_OUTPUT
           fi
 
-      - name: Build Docker image
-        run: |
-          docker build -t prisoner:local .
+      # registers QEMU emulators so the x86 runner can execute arm64 steps
+      # (needed for the `apk add` in the arm64 runtime stage)
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
 
-      - name: Tag and push Docker image
-        env:
-          TAGS: ${{ steps.meta.outputs.tags }}
-        run: |
-          IFS=',' read -ra TAG_ARRAY <<< "$TAGS"
-          for tag in "${TAG_ARRAY[@]}"; do
-            echo "Tagging and pushing: $tag"
-            docker tag prisoner:local "$tag"
-            docker push "$tag"
-          done
+      # sets up the buildx builder that can produce multi-arch manifest lists
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      # builds both arches and pushes the manifest list under all tags in one step
+      - name: Build and push (multi-arch)
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          platforms: linux/amd64,linux/arm64
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          provenance: false
 
       - name: Image digest
         run: |

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.26-alpine AS build
+FROM --platform=$BUILDPLATFORM golang:1.26-alpine AS build
 
 WORKDIR /src
 COPY go.mod go.sum ./
@@ -6,7 +6,9 @@ RUN go mod download
 RUN go install github.com/sqlc-dev/sqlc/cmd/sqlc@v1.31.1
 COPY . .
 RUN sqlc generate
-RUN CGO_ENABLED=0 go build -o /prisoner .
+# TARGETOS/TARGETARCH are set by buildx per target platform; cross-compile to them
+ARG TARGETOS TARGETARCH
+RUN CGO_ENABLED=0 GOOS=$TARGETOS GOARCH=$TARGETARCH go build -o /prisoner .
 
 FROM alpine:3.21
 


### PR DESCRIPTION
This pull request updates the Docker build and publish workflow to support building and pushing multi-architecture (amd64 and arm64) images using Docker Buildx. It also modifies the `Dockerfile` to enable cross-compilation for different target platforms. These changes ensure that the published Docker images are compatible with both x86 and ARM architectures.

**Multi-architecture Docker build and publish:**

* [`.github/workflows/ecr-publish.yaml`](diffhunk://#diff-6ce6cf84ab2b16acff68dc63c83d95c4e8c7d137bddb0094a7da86ff2954aefdL46-R63): Replaces the previous single-architecture Docker build and push steps with steps that set up QEMU, Docker Buildx, and use the `docker/build-push-action` to build and push multi-arch images for both `linux/amd64` and `linux/arm64` in a single step.

**Cross-platform Dockerfile improvements:**

* [`Dockerfile`](diffhunk://#diff-dd2c0eb6ea5cfc6c4bd4eac30934e2d5746747af48fef6da689e85b752f39557L1-R11): Adds `--platform=$BUILDPLATFORM` to the build stage, introduces `ARG TARGETOS TARGETARCH`, and updates the `go build` command to cross-compile for the target platform, enabling multi-architecture builds.