### PR TITLE
Icullinane/add frontend container

### DIFF
--- a/.github/workflows/ecr-publish-web.yaml
+++ b/.github/workflows/ecr-publish-web.yaml
@@ -1,0 +1,71 @@
+name: Build and Push Web to ECR
+
+on:
+  push:
+    branches: [icullinane/version2]   # publish when the SPA changes on the default branch
+    paths: ['web/**']                  # only fire on frontend source changes
+  workflow_dispatch:                   # manual re-publish
+
+# One publish per ref; cancel a superseded build.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+env:
+  AWS_REGION: us-east-2
+  ECR_REPOSITORY: prisoner-web
+
+jobs:
+  build-and-push:
+    name: Build and Push Web Image
+    runs-on: ubuntu-latest
+    permissions:
+      id-token: write        # mint the OIDC token used to assume the AWS role
+      contents: read
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          role-to-assume: ${{ secrets.AWS_ROLE_TO_ASSUME }}
+          aws-region: ${{ env.AWS_REGION }}
+
+      - name: Login to Amazon ECR
+        id: login-ecr
+        uses: aws-actions/amazon-ecr-login@v2
+
+      - name: Extract metadata
+        id: meta
+        run: |
+          # The k8s Deployment pulls :latest; :<short-sha> is an immutable pin.
+          # Versioned :v* release images aren't wired for the frontend yet (paths
+          # filters skip on tags); add a runtime change-filter if you want them.
+          SHORT_SHA=$(git rev-parse --short HEAD)
+          echo "tags=${{ steps.login-ecr.outputs.registry }}/${{ env.ECR_REPOSITORY }}:${SHORT_SHA},${{ steps.login-ecr.outputs.registry }}/${{ env.ECR_REPOSITORY }}:latest" >> $GITHUB_OUTPUT
+
+      # registers QEMU emulators so the x86 runner can build the arm64 image
+      # (the frontend also runs on the arm64 t4g nodes)
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+
+      # buildx builder capable of producing multi-arch manifest lists
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      # build both arches from web/ and push the manifest list under all tags
+      - name: Build and push (multi-arch)
+        uses: docker/build-push-action@v6
+        with:
+          context: ./web
+          platforms: linux/amd64,linux/arm64
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          provenance: false
+
+      - name: Image digest
+        run: |
+          echo "Web image pushed!"
+          echo "Tags: ${{ steps.meta.outputs.tags }}"

--- a/.github/workflows/ecr-publish-web.yaml
+++ b/.github/workflows/ecr-publish-web.yaml
@@ -2,8 +2,8 @@ name: Build and Push Web to ECR
 
 on:
   push:
-    branches: [icullinane/version2]   # publish when the SPA changes on the default branch
-    paths: ['web/**']                  # only fire on frontend source changes
+    branches: [icullinane/version2]   # publish on default-branch merges
+    tags: ['v*']                       # and on release tags (versioned image)
   workflow_dispatch:                   # manual re-publish
 
 # One publish per ref; cancel a superseded build.
@@ -16,8 +16,31 @@ env:
   ECR_REPOSITORY: prisoner-web
 
 jobs:
+  # Cheap gate: did the frontend source actually change? Lets us skip the heavy
+  # image build on backend-only merges. Tag / dispatch runs bypass it via `if:`.
+  # (No base ref on a tag push → paths-filter marks everything changed & succeeds.)
+  changes:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read         # paths-filter reads the push diff via the API
+    outputs:
+      web: ${{ steps.filter.outputs.web }}
+    steps:
+      - uses: dorny/paths-filter@d1c1ffe0248fe513906c8e24db8ea791d46f8590 # v3.0.3
+        id: filter
+        with:
+          filters: |
+            web:
+              - 'web/**'
+
   build-and-push:
     name: Build and Push Web Image
+    needs: changes
+    # build when web/ changed, OR it's a release tag, OR a manual run
+    if: >-
+      needs.changes.outputs.web == 'true' ||
+      startsWith(github.ref, 'refs/tags/') ||
+      github.event_name == 'workflow_dispatch'
     runs-on: ubuntu-latest
     permissions:
       id-token: write        # mint the OIDC token used to assume the AWS role
@@ -40,11 +63,15 @@ jobs:
       - name: Extract metadata
         id: meta
         run: |
-          # The k8s Deployment pulls :latest; :<short-sha> is an immutable pin.
-          # Versioned :v* release images aren't wired for the frontend yet (paths
-          # filters skip on tags); add a runtime change-filter if you want them.
-          SHORT_SHA=$(git rev-parse --short HEAD)
-          echo "tags=${{ steps.login-ecr.outputs.registry }}/${{ env.ECR_REPOSITORY }}:${SHORT_SHA},${{ steps.login-ecr.outputs.registry }}/${{ env.ECR_REPOSITORY }}:latest" >> $GITHUB_OUTPUT
+          # Tag push -> :<version> + :latest ; branch push -> :<short-sha> + :latest.
+          # The k8s Deployment pulls :latest; the other tag is an immutable pin.
+          if [[ $GITHUB_REF == refs/tags/* ]]; then
+            VERSION=${GITHUB_REF#refs/tags/}
+            echo "tags=${{ steps.login-ecr.outputs.registry }}/${{ env.ECR_REPOSITORY }}:${VERSION},${{ steps.login-ecr.outputs.registry }}/${{ env.ECR_REPOSITORY }}:latest" >> $GITHUB_OUTPUT
+          else
+            SHORT_SHA=$(git rev-parse --short HEAD)
+            echo "tags=${{ steps.login-ecr.outputs.registry }}/${{ env.ECR_REPOSITORY }}:${SHORT_SHA},${{ steps.login-ecr.outputs.registry }}/${{ env.ECR_REPOSITORY }}:latest" >> $GITHUB_OUTPUT
+          fi
 
       # registers QEMU emulators so the x86 runner can build the arm64 image
       # (the frontend also runs on the arm64 t4g nodes)

--- a/.github/workflows/ecr-publish.yaml
+++ b/.github/workflows/ecr-publish.yaml
@@ -16,8 +16,32 @@ env:
   ECR_REPOSITORY: prisoner
 
 jobs:
+  # Cheap gate: did any NON-frontend source change? Lets us skip the heavy image
+  # build on web-only merges. Tag / dispatch runs bypass it via `if:`.
+  # (No base ref on a tag push → paths-filter marks everything changed & succeeds.)
+  changes:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read         # paths-filter reads the push diff via the API
+    outputs:
+      backend: ${{ steps.filter.outputs.backend }}
+    steps:
+      - uses: dorny/paths-filter@d1c1ffe0248fe513906c8e24db8ea791d46f8590 # v3.0.3
+        id: filter
+        with:
+          filters: |
+            backend:
+              - '**'          # anything…
+              - '!web/**'      # …except the frontend
+
   build-and-push:
     name: Build and Push Docker Image
+    needs: changes
+    # build when non-web source changed, OR it's a release tag, OR a manual run
+    if: >-
+      needs.changes.outputs.backend == 'true' ||
+      startsWith(github.ref, 'refs/tags/') ||
+      github.event_name == 'workflow_dispatch'
     runs-on: ubuntu-latest
     permissions:
       id-token: write

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -6,7 +6,29 @@
       "bump-minor-pre-major": false,
       "bump-patch-for-minor-pre-major": false,
       "draft": false,
-      "prerelease": false
+      "prerelease": false,
+      "changelog-sections": [
+        {
+          "type": "feat",
+          "section": "Features",
+          "hidden": false
+        },
+        {
+          "type": "fix",
+          "section": "Bug Fixes",
+          "hidden": false
+        },
+        {
+          "type": "ci",
+          "section": "Continuous Integration",
+          "hidden": false
+        },
+        {
+          "type": "chore",
+          "section": "Chores",
+          "hidden": false
+        }
+      ]
     }
   },
   "$schema": "https://raw.githubusercontent.com/googleapis/release-please/main/schemas/config.json"

--- a/web/.dockerignore
+++ b/web/.dockerignore
@@ -1,0 +1,4 @@
+node_modules
+dist
+.git
+*.log

--- a/web/Dockerfile
+++ b/web/Dockerfile
@@ -1,0 +1,30 @@
+# --- build stage: compile the SPA to static files -------------------------
+# node:22-alpine = current LTS on a small base. Vite 6 needs Node 18+.
+FROM node:22-alpine AS build
+WORKDIR /app
+
+# Copy manifests first so the `npm ci` layer caches unless deps change.
+COPY package.json package-lock.json ./
+# npm ci = clean, reproducible install straight from the lockfile.
+RUN npm ci
+
+# Then the source (node_modules + dist excluded via .dockerignore).
+COPY . .
+
+# VITE_API_BASE_URL is inlined into the bundle at BUILD time. Default "" =
+# same-origin relative calls (`/players`); the ALB routes API paths to the
+# backend, so the image is environment-agnostic. Override for cross-origin/dev:
+#   docker build --build-arg VITE_API_BASE_URL=https://api.example.com
+ARG VITE_API_BASE_URL=""
+ENV VITE_API_BASE_URL=$VITE_API_BASE_URL
+RUN npm run build            # tsc -b && vite build  ->  /app/dist
+
+# --- runtime stage: serve the built files with nginx ----------------------
+# Pinned minor; multi-arch base so buildx can emit arm64 for the t4g nodes.
+FROM nginx:1.27-alpine
+# Swap nginx's default server block for our SPA config (fallback + probe).
+COPY nginx.conf /etc/nginx/conf.d/default.conf
+# Ship only the compiled assets, nothing from the build toolchain.
+COPY --from=build /app/dist /usr/share/nginx/html
+EXPOSE 80
+# The nginx base image already runs `nginx -g 'daemon off;'` as its CMD.

--- a/web/nginx.conf
+++ b/web/nginx.conf
@@ -1,0 +1,21 @@
+server {
+    listen 80;
+    server_name _;
+
+    root /usr/share/nginx/html;
+    index index.html;
+
+    # Liveness/readiness probe. The kubelet hits the pod IP directly (not via the
+    # ALB), so this never collides with the backend's /healthz at the Ingress.
+    location = /healthz {
+        access_log off;
+        add_header Content-Type text/plain;
+        return 200 "ok\n";
+    }
+
+    # SPA fallback: any path that isn't a real file serves index.html, so
+    # client-side routes (deep links / refresh) don't 404.
+    location / {
+        try_files $uri $uri/ /index.html;
+    }
+}


### PR DESCRIPTION
This pull request introduces a new Docker-based build and deployment setup for the frontend (`web/`), optimizes backend build triggers, and improves release note generation. The changes add a dedicated multi-architecture Docker build and ECR publish workflow for the frontend, ensure backend images are only rebuilt when relevant files change, and enhance release changelogs with categorized sections. Additionally, new Docker configuration files and an Nginx config for the frontend are included.

**CI/CD Workflow Improvements:**

* Added `.github/workflows/ecr-publish-web.yaml` to build and push the frontend (`web/`) Docker image to ECR, supporting multi-architecture builds (amd64 and arm64), and only triggering on relevant changes, tags, or manual dispatch.
* Updated `.github/workflows/ecr-publish.yaml` to only build and push the backend Docker image when non-frontend files change, optimizing CI resource usage.

**Frontend Dockerization:**

* Added `web/Dockerfile` for a two-stage build: compiling the SPA with Node.js and serving it via Nginx, supporting multi-architecture images and environment-agnostic API base URLs.
* Created `web/.dockerignore` to exclude unnecessary files (`node_modules`, `dist`, `.git`, logs) from the Docker build context.
* Added `web/nginx.conf` to configure Nginx for SPA routing and health checks.

**Release Automation:**

* Enhanced `release-please-config.json` to categorize changelog entries into Features, Bug Fixes, Continuous Integration, and Chores for clearer release notes.